### PR TITLE
COMP: Fix "dirent.h" not found windows build error

### DIFF
--- a/RigidAlignment.cxx
+++ b/RigidAlignment.cxx
@@ -1,5 +1,5 @@
 #include <string>
-#ifdef WIN32
+#ifdef _WIN32
 #include "dirent.h"
 #else
 #include <dirent.h>


### PR DESCRIPTION
This commit is a follow up of 0831c8d44 (COMP: Fix Windows build problems)
that originally introduced `dirent.(h|c)`.

It fixes the following build error reported when building SPHARM-PDM by
ensuring the header `dirent.h` can be found.

It does so by checking `_WIN32` instead of `WIN32`
See https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170#microsoft-specific-predefined-macros

Error:
```
  1>D:\D\P\S-0-E-b\SPHARM-PDM-build\RigidAlignment\RigidAlignment.cxx(5,10): fatal error C1083: Cannot open include file: 'dirent.h': No such file or directory
```